### PR TITLE
Support all net.Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # close-server
 
-Promisified `http.Server.close()`
+Promisified `net.Server.close()`
 
 ## Usage
 
@@ -11,7 +11,7 @@ npm install close-server
 yarn add close-server
 ```
 
-Pass a `http.Server` to `close-server` and it will return a `Promise` which closes the server.
+Pass a `net.Server` (such as `http.Server`) to `close-server` and it will return a `Promise` which closes the server.
 
 ```ts
 import http from 'http';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "close-server",
   "version": "0.0.2",
-  "description": "Promisified http.Server.close()",
+  "description": "Promisified net.Server.close()",
   "main": "dist/index.js",
   "repository": "https://github.com/maxchehab/close-server",
   "author": "Max Chehab <maxchehab@gmail.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,9 @@
-import http from 'http';
+import net from 'net';
 
-export default function closeServer(server: http.Server) {
+export default function closeServer(server: net.Server) {
   return new Promise<void>((resolve, reject) =>
-    server.close((err?: Error) => {
-      if (err) {
-        reject(err);
-      }
-
-      resolve();
-    }),
+    server.close((err?: Error) =>
+      err ? reject(err) : resolve()
+    )
   );
 }


### PR DESCRIPTION
This change adds support for closing all instances of `net.Server`, including [Net](https://nodejs.org/dist/latest/docs/api/net.html#net_class_net_server), [HTTP](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_server), [HTTPS](https://nodejs.org/dist/latest/docs/api/https.html#https_class_https_server), [HTTP/2](https://nodejs.org/dist/latest/docs/api/http2.html#http2_class_http2server), and [TLS](https://nodejs.org/dist/latest/docs/api/tls.html#tls_class_tls_server) `Server` instances.